### PR TITLE
Add support for matcher function returning array

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -63,7 +63,13 @@ module.exports = async function (spec, data, opt = {}) {
       } else if (type == 'matcher' && _.isFunction(want)) {
         const result = await want(got, opt.$)
         if (result) {
-          add(field, result)
+          if (_.isArray(result)) {
+            for (var entry of result) {
+              add(field, entry)
+            }
+          } else {
+            add(field, result)
+          }
         }
       } else if (ext[type] && _.isFunction(ext[type].fn)) {
         await ext[type].fn({

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -483,6 +483,34 @@ describe('validate', () => {
     expect(error).toBeNull()
   })
 
+  it('should accept array from matcher function', async () => {
+    let spec = {
+      val: {
+        matcher: async function (val) {
+          if (val === 5) {
+            return ['can not be 5', 'should not be 5']
+          }
+        }
+      }
+    }
+    let data = {
+      val: 5
+    }
+    let error = await validate(spec, data, opt)
+    expect(error.val).toEqual(['can not be 5', 'should not be 5'])
+
+    data = {
+      val: 4
+    }
+    error = await validate(spec, data, opt)
+    expect(error).toBeNull()
+
+    data = {}
+
+    error = await validate(spec, data, opt)
+    expect(error).toBeNull()
+  })
+
   // Test length
   it('should have a length', async () => {
     let spec = {


### PR DESCRIPTION
Allow matcher functions to return an array of errors.
Add unit test.